### PR TITLE
fix(Makefile): don't show k8s claimer token via make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ include versioning.mk
 REPO_PATH := github.com/deis/${SHORT_NAME}
 DEV_ENV_IMAGE := quay.io/deis/go-dev:0.19.0
 DEV_ENV_WORK_DIR := /go/src/${REPO_PATH}
-DEV_ENV_PREFIX := docker run -it --rm -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR} -e K8S_CLAIMER_AUTH_TOKEN=${K8S_CLAIMER_AUTH_TOKEN}
+K8S_CLAIMER_SUFFIX := -e K8S_CLAIMER_AUTH_TOKEN=${K8S_CLAIMER_AUTH_TOKEN}
+DEV_ENV_PREFIX := docker run -it --rm -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR}
 DEV_ENV_CMD := ${DEV_ENV_PREFIX} ${DEV_ENV_IMAGE}
 
 BINARY_DEST_DIR := rootfs/bin
@@ -38,10 +39,16 @@ test-unit:
 	${DEV_ENV_CMD} sh -c 'go test $$(glide nv)'
 
 test-all:
-	${DEV_ENV_CMD} sh -c 'go run testing/test_driver.go go test -tags integration $$(glide nv)'
+	@${DEV_ENV_PREFIX} \
+		${K8S_CLAIMER_SUFFIX} \
+		${DEV_ENV_IMAGE} \
+		sh -c 'go run testing/test_driver.go go test -tags integration $$(glide nv)'
 
 test-cover:
-	@${DEV_ENV_CMD} sh -c 'go run testing/test_driver.go _scripts/test-cover.sh'
+	@${DEV_ENV_PREFIX} \
+		${K8S_CLAIMER_SUFFIX} \
+		${DEV_ENV_IMAGE} \
+		sh -c 'go run testing/test_driver.go _scripts/test-cover.sh'
 
 docker-build: build
 	${DEV_ENV_CMD} upx -9 ${BINARY_DEST_DIR}/${SHORT_NAME}


### PR DESCRIPTION
I'll execute a similar strategy on deis/steward-framework as soon as I get the LGTM on this effort.