### PR TITLE
chore(fw): Upgrade to the latest framework and its new architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,6 @@ vendor
 /coverage.txt
 rootfs/bin/steward-cf.000
 
-manifests/*-steward-cf.yaml
-manifests/*-steward-cf.yaml.bak
+manifests/steward-cf.yaml
 
 kubeconfig.yaml

--- a/Makefile
+++ b/Makefile
@@ -61,35 +61,10 @@ install-namespace:
 DEPLOY_IMAGE ?= quay.io/deisci/${SHORT_NAME}:devel
 
 install:
-ifndef BROKER_NAME
-	$(error BROKER_NAME is undefined)
-endif
-ifndef BROKER_ACCESS_SCHEME
-	$(error BROKER_ACCESS_SCHEME is undefined)
-endif
-ifndef BROKER_HOST
-	$(error BROKER_HOST is undefined)
-endif
-ifndef BROKER_PORT
-	$(error BROKER_PORT is undefined)
-endif
-ifndef BROKER_USERNAME
-	$(error BROKER_USERNAME is undefined)
-endif
-ifndef BROKER_PASSWORD
-	$(error BROKER_PASSWORD is undefined)
-endif
-	sed "s/#broker_name#/${BROKER_NAME}/g" manifests/${SHORT_NAME}-template.yaml > manifests/${BROKER_NAME}-${SHORT_NAME}.yaml
-	sed -i.bak "s/#broker_access_scheme#/${BROKER_ACCESS_SCHEME}/g" manifests/${BROKER_NAME}-${SHORT_NAME}.yaml
-	sed -i.bak "s/#broker_host#/${BROKER_HOST}/g" manifests/${BROKER_NAME}-${SHORT_NAME}.yaml
-	sed -i.bak "s/#broker_port#/${BROKER_PORT}/g" manifests/${BROKER_NAME}-${SHORT_NAME}.yaml
-	sed -i.bak "s/#broker_username#/${BROKER_USERNAME}/g" manifests/${BROKER_NAME}-${SHORT_NAME}.yaml
-	sed -i.bak "s/#broker_password#/${BROKER_PASSWORD}/g" manifests/${BROKER_NAME}-${SHORT_NAME}.yaml
-	sed -i.bak "s#\#deploy_image\##${DEPLOY_IMAGE}#g" manifests/${BROKER_NAME}-${SHORT_NAME}.yaml
-	rm manifests/${BROKER_NAME}-${SHORT_NAME}.yaml.bak
-	kubectl get deployment ${BROKER_NAME}-${SHORT_NAME} --namespace=steward && \
-	kubectl apply -f manifests/${BROKER_NAME}-${SHORT_NAME}.yaml || \
-	kubectl create -f manifests/${BROKER_NAME}-${SHORT_NAME}.yaml
+	sed "s#\#deploy_image\##${DEPLOY_IMAGE}#g" manifests/${SHORT_NAME}-template.yaml > manifests/${SHORT_NAME}.yaml
+	kubectl get deployment ${SHORT_NAME} --namespace=steward && \
+	kubectl apply -f manifests/${SHORT_NAME}.yaml || \
+	kubectl create -f manifests/${SHORT_NAME}.yaml
 
 deploy: install-namespace install
 

--- a/config.go
+++ b/config.go
@@ -8,11 +8,9 @@ import (
 )
 
 type config struct {
-	BrokerName      string   `envconfig:"BROKER_NAME" required:"true"`
-	Namespaces      []string `envconfig:"WATCH_NAMESPACES" default:"default"`
-	MaxAsyncMinutes int      `envconfig:"MAX_ASYNC_MINUTES" default:"60"`
-	APIPort         int      `envconfig:"API_PORT" default:"8080"`
-	LogLevel        string   `envconfig:"LOG_LEVEL" default:"info"`
+	MaxAsyncMinutes int    `envconfig:"MAX_ASYNC_MINUTES" default:"60"`
+	APIPort         int    `envconfig:"API_PORT" default:"8080"`
+	LogLevel        string `envconfig:"LOG_LEVEL" default:"info"`
 }
 
 func getConfig() (*config, error) {

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: fa16b5c022e632dfe18b9a0748a4cae0a16a069c2afb527e1f52c44764aeff56
-updated: 2016-11-08T10:47:25.446200297-05:00
+hash: 1a47971d3ec645bd96d0169176d9c9e150d511fe30dc1401192a64d581524a2f
+updated: 2016-11-28T15:33:59.154420039-05:00
 imports:
 - name: github.com/arschles/assert
   version: bb58b908265b5931732079df03f2818bf2167ba0
@@ -33,11 +33,16 @@ imports:
   - htp
   - k8s
 - name: github.com/deis/steward-framework
-  version: 3d1c2c1591cd158c893ceb808cfd88ccbcab5b14
+  version: 5d58b53709b3b2a9b5a87445ab61f5bd183b2b81
   subpackages:
   - k8s
-  - k8s/claim
-  - k8s/claim/state
+  - k8s/binding
+  - k8s/broker
+  - k8s/clients
+  - k8s/data
+  - k8s/instance
+  - k8s/refs
+  - k8s/tprs
   - lib
   - runner
   - web/api
@@ -100,13 +105,13 @@ imports:
 - name: github.com/mattn/go-isatty
   version: 66b8e73f3f5cda9f96b69efd03dd3d7fc4a5cdb8
 - name: github.com/pborman/uuid
-  version: 3d4f2ba23642d3cfd06bd4b54cf03d99d95c0f1b
+  version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
 - name: github.com/PuerkitoBio/purell
   version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
 - name: github.com/PuerkitoBio/urlesc
   version: 5bd2802263f21d8788851d5305584c82a5c75d7e
 - name: github.com/spf13/pflag
-  version: c7e63cf4530bcd3ba943729cee0efeff2ebea63f
+  version: 5ccb023bc27df288a957c5e994cd44fd19619465
 - name: github.com/technosophos/moniker
   version: 9f956786b91d9786ca11aa5be6104542fa911546
 - name: github.com/ugorji/go
@@ -163,19 +168,21 @@ imports:
 - name: gopkg.in/yaml.v2
   version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
 - name: k8s.io/client-go
-  version: 24b73253cdf216313fc6bcc0b459d48dc838a24f
+  version: 89c60099837a47cfce19bd14e2d1f16c4670fd58
   subpackages:
   - discovery
+  - dynamic
   - kubernetes
-  - kubernetes/typed/apps/v1alpha1
+  - kubernetes/typed/apps/v1beta1
   - kubernetes/typed/authentication/v1beta1
   - kubernetes/typed/authorization/v1beta1
   - kubernetes/typed/autoscaling/v1
   - kubernetes/typed/batch/v1
+  - kubernetes/typed/batch/v2alpha1
   - kubernetes/typed/certificates/v1alpha1
   - kubernetes/typed/core/v1
   - kubernetes/typed/extensions/v1beta1
-  - kubernetes/typed/policy/v1alpha1
+  - kubernetes/typed/policy/v1beta1
   - kubernetes/typed/rbac/v1alpha1
   - kubernetes/typed/storage/v1beta1
   - pkg/api
@@ -192,7 +199,7 @@ imports:
   - pkg/apimachinery/registered
   - pkg/apis/apps
   - pkg/apis/apps/install
-  - pkg/apis/apps/v1alpha1
+  - pkg/apis/apps/v1beta1
   - pkg/apis/authentication
   - pkg/apis/authentication/install
   - pkg/apis/authentication/v1beta1
@@ -214,7 +221,7 @@ imports:
   - pkg/apis/extensions/v1beta1
   - pkg/apis/policy
   - pkg/apis/policy/install
-  - pkg/apis/policy/v1alpha1
+  - pkg/apis/policy/v1beta1
   - pkg/apis/rbac
   - pkg/apis/rbac/install
   - pkg/apis/rbac/v1alpha1
@@ -236,6 +243,7 @@ imports:
   - pkg/runtime/serializer/versioning
   - pkg/selection
   - pkg/third_party/forked/golang/reflect
+  - pkg/third_party/forked/golang/template
   - pkg/types
   - pkg/util
   - pkg/util/cert
@@ -247,10 +255,12 @@ imports:
   - pkg/util/integer
   - pkg/util/intstr
   - pkg/util/json
+  - pkg/util/jsonpath
   - pkg/util/labels
   - pkg/util/net
   - pkg/util/parsers
   - pkg/util/rand
+  - pkg/util/ratelimit
   - pkg/util/runtime
   - pkg/util/sets
   - pkg/util/uuid
@@ -272,8 +282,4 @@ imports:
   - tools/clientcmd/api/v1
   - tools/metrics
   - transport
-- name: k8s.io/kubernetes
-  version: c41c24fbf300cd7ba504ea1ac2e052c4a1bbed33
-  subpackages:
-  - pkg/util/ratelimit
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -27,6 +27,8 @@ import:
 - package: github.com/juju/loggo
 - package: github.com/arschles/testsrv
 - package: k8s.io/client-go
+  version: 89c60099837a47cfce19bd14e2d1f16c4670fd58
 - package: github.com/deis/k8s-claimer
 - package: github.com/technosophos/moniker
 - package: github.com/deis/steward-framework
+  version: 5d58b53709b3b2a9b5a87445ab61f5bd183b2b81

--- a/lib/binder.go
+++ b/lib/binder.go
@@ -21,6 +21,7 @@ func newBinder(cl *restClient) *binder {
 
 func (b *binder) Bind(
 	ctx context.Context,
+	brokerSpec framework.BrokerSpec,
 	req *framework.BindRequest,
 ) (*framework.BindResponse, error) {
 
@@ -30,6 +31,7 @@ func (b *binder) Bind(
 	}
 
 	apiReq, err := b.cl.Put(
+		brokerSpec,
 		emptyQuery,
 		bodyBytes,
 		"v2",

--- a/lib/catalog_integration_test.go
+++ b/lib/catalog_integration_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestCFCataloger(t *testing.T) {
-	services, err := testCataloger.List(context.Background())
+	services, err := testCataloger.List(context.Background(), testBrokerSpec)
 	assert.NoErr(t, err)
 	// Compare to known results from cf-sample-broker...
 	expectedServiceCount := 3

--- a/lib/cataloger.go
+++ b/lib/cataloger.go
@@ -18,8 +18,11 @@ func newCataloger(cl *restClient) *cataloger {
 	}
 }
 
-func (c *cataloger) List(ctx context.Context) ([]*framework.Service, error) {
-	req, err := c.cl.Get(emptyQuery, "v2", "catalog")
+func (c *cataloger) List(
+	ctx context.Context,
+	brokerSpec framework.BrokerSpec,
+) ([]*framework.Service, error) {
+	req, err := c.cl.Get(brokerSpec, emptyQuery, "v2", "catalog")
 	if err != nil {
 		return nil, err
 	}

--- a/lib/common_integration_test.go
+++ b/lib/common_integration_test.go
@@ -3,8 +3,8 @@
 package lib
 
 import (
+	"fmt"
 	"log"
-	"os"
 	"sync"
 	"testing"
 	"time"
@@ -24,6 +24,10 @@ var (
 	testCataloger  framework.Cataloger
 	testLifecycler framework.Lifecycler
 	testNamespace  string
+	testBrokerSpec = framework.BrokerSpec{
+		Username: "admin",
+		Password: "password",
+	}
 )
 
 func TestMain(m *testing.M) {
@@ -194,11 +198,7 @@ func ensureBroker() error {
 	// reluctantly, we're waiting an extra 30 seconds here. With This extra bit of padding, the
 	// first response from the sample broker is reliably received in little more than 100 ms.
 	time.Sleep(time.Duration(30) * time.Second)
-	os.Setenv("BROKER_ACCESS_SCHEME", "http")
-	os.Setenv("BROKER_HOST", service.Status.LoadBalancer.Ingress[0].IP)
-	os.Setenv("BROKER_PORT", "80")
-	os.Setenv("BROKER_USERNAME", "admin")
-	os.Setenv("BROKER_PASSWORD", "password")
+	testBrokerSpec.URL = fmt.Sprintf("http://%s", service.Status.LoadBalancer.Ingress[0].IP)
 	return nil
 }
 

--- a/lib/config.go
+++ b/lib/config.go
@@ -7,12 +7,7 @@ import (
 )
 
 type config struct {
-	BrokerAccessScheme      string `envconfig:"BROKER_ACCESS_SCHEME" required:"true"`
-	BrokerHost              string `envconfig:"BROKER_HOST" required:"true"`
-	BrokerPort              int    `envconfig:"BROKER_PORT" required:"true"`
-	BrokerUsername          string `envconfig:"BROKER_USERNAME" required:"true"`
-	BrokerPassword          string `envconfig:"BROKER_PASSWORD" required:"true"`
-	BrokerRequestTimeoutSec int    `envconfig:"BROKER_REQUEST_TIMEOUT_SEC" default:"5"`
+	BrokerRequestTimeoutSec int `envconfig:"BROKER_REQUEST_TIMEOUT_SEC" default:"5"`
 }
 
 func getConfig() (config, error) {

--- a/lib/deprovisioner.go
+++ b/lib/deprovisioner.go
@@ -21,6 +21,7 @@ func newDeprovisioner(cl *restClient) *deprovisioner {
 
 func (d *deprovisioner) Deprovision(
 	ctx context.Context,
+	brokerSpec framework.BrokerSpec,
 	req *framework.DeprovisionRequest,
 ) (*framework.DeprovisionResponse, error) {
 
@@ -28,7 +29,7 @@ func (d *deprovisioner) Deprovision(
 	query.Add(serviceIDQueryKey, req.ServiceID)
 	query.Add(planIDQueryKey, req.PlanID)
 	query.Add(asyncQueryKey, "true")
-	apiReq, err := d.cl.Delete(query, "v2", "service_instances", req.InstanceID)
+	apiReq, err := d.cl.Delete(brokerSpec, query, "v2", "service_instances", req.InstanceID)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/lifecycle_integration_test.go
+++ b/lib/lifecycle_integration_test.go
@@ -19,12 +19,16 @@ const (
 )
 
 func TestProvision(t *testing.T) {
-	resp, err := testLifecycler.Provision(context.Background(), &framework.ProvisionRequest{
-		InstanceID:        fakeInstanceID,
-		ServiceID:         fakeServiceID,
-		PlanID:            fakePlanID,
-		AcceptsIncomplete: true,
-	})
+	resp, err := testLifecycler.Provision(
+		context.Background(),
+		testBrokerSpec,
+		&framework.ProvisionRequest{
+			InstanceID:        fakeInstanceID,
+			ServiceID:         fakeServiceID,
+			PlanID:            fakePlanID,
+			AcceptsIncomplete: true,
+		},
+	)
 	assert.NoErr(t, err)
 	// Compare to known results from cf-sample-broker...
 	assert.Equal(t, resp, &framework.ProvisionResponse{
@@ -33,35 +37,47 @@ func TestProvision(t *testing.T) {
 }
 
 func TestBind(t *testing.T) {
-	resp, err := testLifecycler.Bind(context.Background(), &framework.BindRequest{
-		InstanceID: fakeInstanceID,
-		ServiceID:  fakeServiceID,
-		PlanID:     fakePlanID,
-		BindingID:  fakeBindingID,
-	})
+	resp, err := testLifecycler.Bind(
+		context.Background(),
+		testBrokerSpec,
+		&framework.BindRequest{
+			InstanceID: fakeInstanceID,
+			ServiceID:  fakeServiceID,
+			PlanID:     fakePlanID,
+			BindingID:  fakeBindingID,
+		},
+	)
 	assert.NoErr(t, err)
 	// Compare to known results from cf-sample-broker...
 	assert.Equal(t, len(resp.Creds), 10, "credentials count")
 }
 
 func TestUnbind(t *testing.T) {
-	err := testLifecycler.Unbind(context.Background(), &framework.UnbindRequest{
-		InstanceID: fakeInstanceID,
-		ServiceID:  fakeServiceID,
-		PlanID:     fakePlanID,
-		BindingID:  fakeBindingID,
-	})
+	err := testLifecycler.Unbind(
+		context.Background(),
+		testBrokerSpec,
+		&framework.UnbindRequest{
+			InstanceID: fakeInstanceID,
+			ServiceID:  fakeServiceID,
+			PlanID:     fakePlanID,
+			BindingID:  fakeBindingID,
+		},
+	)
 	// Unbind returns no result except for any error that occurred...
 	assert.NoErr(t, err)
 }
 
 func TestDeprovision(t *testing.T) {
-	resp, err := testLifecycler.Deprovision(context.Background(), &framework.DeprovisionRequest{
-		InstanceID:        fakeInstanceID,
-		ServiceID:         fakeServiceID,
-		PlanID:            fakePlanID,
-		AcceptsIncomplete: true,
-	})
+	resp, err := testLifecycler.Deprovision(
+		context.Background(),
+		testBrokerSpec,
+		&framework.DeprovisionRequest{
+			InstanceID:        fakeInstanceID,
+			ServiceID:         fakeServiceID,
+			PlanID:            fakePlanID,
+			AcceptsIncomplete: true,
+		},
+	)
 	assert.NoErr(t, err)
 	// Compare to known results from cf-sample-broker...
 	assert.Equal(t, resp, &framework.DeprovisionResponse{

--- a/lib/operation_status_retriever.go
+++ b/lib/operation_status_retriever.go
@@ -21,6 +21,7 @@ func newOperationStatusRetriever(cl *restClient) *operationStatusRetriever {
 
 func (o *operationStatusRetriever) GetOperationStatus(
 	ctx context.Context,
+	brokerSpec framework.BrokerSpec,
 	req *framework.OperationStatusRequest,
 ) (*framework.OperationStatusResponse, error) {
 
@@ -28,7 +29,7 @@ func (o *operationStatusRetriever) GetOperationStatus(
 	query.Add(serviceIDQueryKey, req.ServiceID)
 	query.Add(planIDQueryKey, req.PlanID)
 	query.Add(operationQueryKey, req.Operation)
-	apiReq, err := o.cl.Get(query, "v2", "service_instances", req.InstanceID, "last_operation")
+	apiReq, err := o.cl.Get(brokerSpec, query, "v2", "service_instances", req.InstanceID, "last_operation")
 	if err != nil {
 		return nil, err
 	}

--- a/lib/provisioner.go
+++ b/lib/provisioner.go
@@ -22,6 +22,7 @@ func newProvisioner(cl *restClient) *provisioner {
 
 func (p *provisioner) Provision(
 	ctx context.Context,
+	brokerSpec framework.BrokerSpec,
 	req *framework.ProvisionRequest,
 ) (*framework.ProvisionResponse, error) {
 
@@ -32,6 +33,7 @@ func (p *provisioner) Provision(
 		return nil, err
 	}
 	apiReq, err := p.cl.Put(
+		brokerSpec,
 		query,
 		bodyBytes,
 		"v2",

--- a/lib/unbinder.go
+++ b/lib/unbinder.go
@@ -20,6 +20,7 @@ func newUnbinder(cl *restClient) *unbinder {
 
 func (u *unbinder) Unbind(
 	ctx context.Context,
+	brokerSpec framework.BrokerSpec,
 	req *framework.UnbindRequest,
 ) error {
 
@@ -27,6 +28,7 @@ func (u *unbinder) Unbind(
 	query.Add(serviceIDQueryKey, req.ServiceID)
 	query.Add(planIDQueryKey, req.PlanID)
 	apiReq, err := u.cl.Delete(
+		brokerSpec,
 		query,
 		"v2",
 		"service_instances",

--- a/main.go
+++ b/main.go
@@ -27,8 +27,6 @@ func main() {
 	}
 
 	if err = runner.Run(
-		cfg.BrokerName,
-		cfg.Namespaces,
 		cataloger,
 		lifecycler,
 		cfg.getMaxAsyncDuration(),

--- a/manifests/steward-cf-template.yaml
+++ b/manifests/steward-cf-template.yaml
@@ -1,38 +1,24 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: #broker_name#-steward-cf
+  name: steward-cf
   namespace: steward
   labels:
-    app: #broker_name#-steward-cf
+    app: steward-cf
 spec:
   replicas: 1
   template:
     metadata:
       labels:
-        app: #broker_name#-steward-cf
+        app: steward-cf
     spec:
       containers:
-      - name: #broker_name#-steward-cf
+      - name: steward-cf
         image: #deploy_image#
         imagePullPolicy: Always
         env:
-        - name: BROKER_NAME
-          value: #broker_name#
         - name: LOG_LEVEL
           value: trace
-        - name: WATCH_NAMESPACES
-          value: default
-        - name: BROKER_ACCESS_SCHEME
-          value: "#broker_access_scheme#"
-        - name: BROKER_HOST
-          value: "#broker_host#"
-        - name: BROKER_PORT
-          value: "#broker_port#"
-        - name: BROKER_USERNAME
-          value: "#broker_username#"
-        - name: BROKER_PASSWORD
-          value: "#broker_password#"
         livenessProbe:
           httpGet:
             path: /healthz
@@ -51,17 +37,3 @@ spec:
           periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 2
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: #broker_name#-steward-cf
-  namespace: steward
-  labels:
-    app: #broker_name#-steward-cf
-spec:
-  ports:
-  - port: 80
-    targetPort: 8080
-  selector:
-    app: #broker_name#-steward-cf


### PR DESCRIPTION
Closes #15 
Closes #17 

I'd like for this to marinate for a bit before we consider merging.

Requires https://github.com/deis/steward-framework/pull/53 and a `glide.yaml` update to use the new steward-framework dependency.