### PR TITLE
fix(.gitignore): ignore binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ manifests/*-steward-cf.yaml
 manifests/*-steward-cf.yaml.bak
 
 kubeconfig.yaml
+steward-cf


### PR DESCRIPTION
when they’re built by ‘go build’